### PR TITLE
[BUGFIX] Fix auto-rotate using GraphicsMagick

### DIFF
--- a/Classes/Service/ImageResizer.php
+++ b/Classes/Service/ImageResizer.php
@@ -14,6 +14,7 @@
 
 namespace Causal\ImageAutoresize\Service;
 
+use Causal\ImageAutoresize\Utility\ImageUtility;
 use TYPO3\CMS\Core\Resource\Exception\FolderDoesNotExistException;
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\Index\Indexer;
@@ -21,7 +22,6 @@ use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Resource\ResourceStorage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
-use Causal\ImageAutoresize\Utility\ImageUtility;
 
 /**
  * This is a utility class to resize pictures based on rules.
@@ -350,7 +350,7 @@ class ImageResizer
             $this->lastMetadata['COMPUTED']['Width'] = $tempFileInfo[0];
             $this->lastMetadata['COMPUTED']['Height'] = $tempFileInfo[1];
 
-            if ($isRotated && (bool)$ruleset['keep_metadata'] === true && $GLOBALS['TYPO3_CONF_VARS']['GFX']['im_version_5'] === 'gm') {
+            if ($isRotated && (bool)$ruleset['keep_metadata'] === true && $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'] === 'GraphicsMagick') {
                 ImageUtility::resetOrientation($destFileName);
             }
 

--- a/Classes/Utility/ImageUtility.php
+++ b/Classes/Utility/ImageUtility.php
@@ -280,11 +280,7 @@ class ImageUtility
     public static function getTransformation($orientation)
     {
         $transformation = '';
-        if (
-            (isset($GLOBALS['TYPO3_CONF_VARS']['GFX']['processor']) && $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'] === 'ImageMagick')
-            ||
-            (isset($GLOBALS['TYPO3_CONF_VARS']['GFX']['im_version_5']) && $GLOBALS['TYPO3_CONF_VARS']['GFX']['im_version_5'] !== 'gm')
-        ) {
+        if ($GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'] !== 'GraphicsMagick') {
             // ImageMagick
             if ($orientation >= 2 && $orientation <= 8) {
                 $transformation = '-auto-orient';


### PR DESCRIPTION
The former bugfix in
https://github.com/xperseguers/t3ext-image_autoresize/commit/b25d62c5fb653275da971479607e71d81d6cb626
was faulty as even TYPO3 8.0 uses a SilentMigration to change
GFX/im_version_5 to GFX/processor in
https://review.typo3.org/c/Packages/TYPO3.CMS/+/42385/18/typo3/sysext/install/Classes/Service/SilentConfigurationUpgradeService.php#441

This patch fixes this issue and additionally fixes a problem with
GraphicsMagick where images were rotated but the exif orientation was
not reset leading to wrongly rotated images.

Fixes https://github.com/xperseguers/t3ext-image_autoresize/issues/23