### PR TITLE
Handle configuration by hook

### DIFF
--- a/Classes/Controller/ConfigurationController.php
+++ b/Classes/Controller/ConfigurationController.php
@@ -419,6 +419,10 @@ HTML;
         $config = file_exists($configurationFileName) ? include($configurationFileName) : [];
         if (!is_array($config) || empty($config)) {
             $config = static::getDefaultConfiguration();
+            // Merge with eventual hook configuration
+            if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['image_autoresize']['defaultConfiguration'])) {
+                $config = array_merge($config, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['image_autoresize']['defaultConfiguration']);
+            }
         }
 
         return $config;


### PR DESCRIPTION
Fix #28 

To be used in custom extension's `ext_localconf.php`.
Eg:
```
$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['image_autoresize']['defaultConfiguration'] = [
    'file_types' => 'jpg,jpeg,png,gif',
    'max_width' => '1920',
    'max_height' => '1280',
    'max_size' => '10M'
];
```

Downside: if multiple extensions are implementing the hook, only the last one loaded in `PackageStates.php` will be used.