### PR TITLE
[BUGFIX] Cast width/height to int

### DIFF
--- a/Classes/Slots/FileUpload.php
+++ b/Classes/Slots/FileUpload.php
@@ -225,8 +225,8 @@ class FileUpload
             \Causal\ImageAutoresize\Utility\FAL::indexFile(
                 $file,
                 '', '',
-                static::$metadata['COMPUTED']['Width'],
-                static::$metadata['COMPUTED']['Height'],
+                (int)static::$metadata['COMPUTED']['Width'],
+                (int)static::$metadata['COMPUTED']['Height'],
                 static::$metadata
             );
         }


### PR DESCRIPTION
On some servers the graphical functions for retrieving
file metadata results float values for width/height
which will break calling indexFile which exprects
width/height as int

Resolves: #48