### PR TITLE
[BUGFIX] add undefined property

### DIFF
--- a/Classes/Controller/ConfigurationController.php
+++ b/Classes/Controller/ConfigurationController.php
@@ -78,6 +78,11 @@ class ConfigurationController
     public $content = '';
 
     /**
+     * @var string
+     */
+    protected $retUrl = '';
+
+    /**
      * Default constructor
      */
     public function __construct()


### PR DESCRIPTION
add undefined property retUrl


$this->retUrl is undefined in https://github.com/xperseguers/t3ext-image_autoresize/blob/master/Classes/Controller/ConfigurationController.php#L228

Could probably also be removed, don't know if it is used in older typo3 versions.