### PR TITLE
[BUGFIX] Remove PHP Warning: Undefined array key from ImageUtility

### DIFF
--- a/Classes/Utility/ImageUtility.php
+++ b/Classes/Utility/ImageUtility.php
@@ -162,7 +162,7 @@ class ImageUtility
             if ($exif) {
                 $metadata = $exif;
                 // Fix description coming from EXIF
-                $metadata['ImageDescription'] = static::safeUtf8Encode($metadata['ImageDescription']);
+                $metadata['ImageDescription'] = static::safeUtf8Encode($metadata['ImageDescription'] ?? '');
 
                 // Process the longitude/latitude/altitude
                 if (isset($metadata['GPSLatitude']) && is_array($metadata['GPSLatitude'])) {


### PR DESCRIPTION
With PHP 8 `$metadata['ImageDescription']` if the key doesn't exist we have a warning that can block the upload of an image
