### PR TITLE
[FEATURE] Dispatch Event when default configuration is retrieved

### DIFF
--- a/Classes/Controller/ConfigurationController.php
+++ b/Classes/Controller/ConfigurationController.php
@@ -14,6 +14,8 @@
 
 namespace Causal\ImageAutoresize\Controller;
 
+use Causal\ImageAutoresize\Event\ProcessDefaultConfigurationEvent;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
@@ -433,6 +435,9 @@ HTML;
         $configuration = file_exists($configurationFileName) ? include($configurationFileName) : [];
         if (!is_array($configuration) || empty($configuration)) {
             $configuration = static::getDefaultConfiguration();
+
+            $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+            $configuration = $eventDispatcher->dispatch(new ProcessDefaultConfigurationEvent($configuration))->getConfiguration();
         }
 
         $signalSlotDispatcher = GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class);

--- a/Classes/Event/ProcessDefaultConfigurationEvent.php
+++ b/Classes/Event/ProcessDefaultConfigurationEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Causal\ImageAutoresize\Event;
+
+final class ProcessDefaultConfigurationEvent
+{
+    /**
+     * @param array
+     */
+    private $configuration;
+
+    public function __construct(array $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfiguration()
+    {
+        return $this->configuration;
+    }
+
+    /**
+     * @param array $configuration
+     * @return void
+     */
+    public function setConfiguration(array $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+}


### PR DESCRIPTION
Hello Xavier,

Better late than never, 9 months later here is my proposal for #40

As said in the issue, use case could be:

an extension as bootstrap_package for example, could make an EventListener to propose a default configuration for image_autoresize, but the final user would be allowed to have the final word in the extension module, without having to write some code.