### PR TITLE
[FIX] Use TYPO3 FlashMessageService instead of fakeSchedulerModuleCon…

### DIFF
--- a/Classes/Task/BatchResizeAdditionalFieldProvider.php
+++ b/Classes/Task/BatchResizeAdditionalFieldProvider.php
@@ -18,8 +18,10 @@ declare(strict_types=1);
 namespace Causal\ImageAutoresize\Task;
 
 use Causal\ImageAutoresize\Utility\FAL;
-use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Scheduler\Task\Enumeration\Action;
 
 /**
@@ -121,13 +123,21 @@ class BatchResizeAdditionalFieldProvider implements \TYPO3\CMS\Scheduler\Additio
             $directoryConfig = FAL::getDirectoryConfig($directory);
             if (!@is_dir($directoryConfig['basePath'] . $directoryConfig['directory'])) {
                 $result = false;
-                (new fakeSchedulerModuleController())->addMessage(
+
+                $message = GeneralUtility::makeInstance(
+                    FlashMessage::class,
                     sprintf(
                         $GLOBALS['LANG']->sL('LLL:EXT:image_autoresize/Resources/Private/Language/locallang_mod.xlf:msg.invalidDirectories'),
                         $directory
                     ),
-                    FlashMessage::ERROR
+                    'EXT:image_autoresize: invalidDirectories error',
+                    ContextualFeedbackSeverity::ERROR,
+                    true
                 );
+
+                $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
+                $messageQueue = $flashMessageService->getMessageQueueByIdentifier();
+                $messageQueue->addMessage($message);
             }
         }
 
@@ -136,12 +146,21 @@ class BatchResizeAdditionalFieldProvider implements \TYPO3\CMS\Scheduler\Additio
             $directoryConfig = FAL::getDirectoryConfig($directory);
             if (!@is_dir($directoryConfig['basePath'] . $directoryConfig['directory'])) {
                 $result = false;
-                (new fakeSchedulerModuleController())->addMessage(
+
+                $message = GeneralUtility::makeInstance(
+                    FlashMessage::class,
                     sprintf(
                         $GLOBALS['LANG']->sL('LLL:EXT:image_autoresize/Resources/Private/Language/locallang_mod.xlf:msg.invalidExcludeDirectories'),
                         $directory
                     ),
-                    FlashMessage::ERROR);
+                    'EXT:image_autoresize: invalidExcludeDirectories error',
+                    ContextualFeedbackSeverity::ERROR,
+                    true
+                );
+
+                $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
+                $messageQueue = $flashMessageService->getMessageQueueByIdentifier();
+                $messageQueue->addMessage($message);
             }
         }
 
@@ -159,14 +178,5 @@ class BatchResizeAdditionalFieldProvider implements \TYPO3\CMS\Scheduler\Additio
         /** @var \Causal\ImageAutoresize\Task\BatchResizeTask $task */
         $task->directories = trim($submittedData['scheduler_batchResize_directories']);
         $task->excludeDirectories = trim($submittedData['scheduler_batchResize_excludeDirectories']);
-    }
-
-}
-
-class fakeSchedulerModuleController extends \TYPO3\CMS\Scheduler\Controller\SchedulerModuleController
-{
-    public function addMessage($message, $severity = FlashMessage::OK)
-    {
-        parent::addMessage($message, $severity);
     }
 }


### PR DESCRIPTION
- Fixes #73 - Invalid method signature which blocks Scheduler-Creation
- Also @see: https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/FlashMessages/Index.html