### PR TITLE
[Fix] Fix missing second param for TYPO3 logger, use \Psr\Log\LogLeve…

### DIFF
--- a/Classes/Task/BatchResizeTask.php
+++ b/Classes/Task/BatchResizeTask.php
@@ -266,7 +266,7 @@ class BatchResizeTask extends \TYPO3\CMS\Scheduler\Task\AbstractTask
                 $logger->info($message);
                 break;
             case \TYPO3\CMS\Core\Messaging\FlashMessage::OK:
-                $logger->log($message);
+                $logger->log(\Psr\Log\LogLevel::INFO, $message);
                 break;
             case \TYPO3\CMS\Core\Messaging\FlashMessage::WARNING:
                 $logger->warning($message);

--- a/Classes/Task/BatchResizeTask.php
+++ b/Classes/Task/BatchResizeTask.php
@@ -266,7 +266,7 @@ class BatchResizeTask extends \TYPO3\CMS\Scheduler\Task\AbstractTask
                 $logger->info($message);
                 break;
             case \TYPO3\CMS\Core\Messaging\FlashMessage::OK:
-                $logger->log(\Psr\Log\LogLevel::INFO, $message);
+                $logger->info($message);
                 break;
             case \TYPO3\CMS\Core\Messaging\FlashMessage::WARNING:
                 $logger->warning($message);


### PR DESCRIPTION
…l::INFO

@see: https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/Logging/Logger/Index.html#log-levels-and-shorthand-methods