### PR TITLE
[Fix][critical] Delete temporary created images in typo3temp/assets/images, if skipped

### DIFF
--- a/Classes/Service/ImageResizer.php
+++ b/Classes/Service/ImageResizer.php
@@ -353,6 +353,7 @@ class ImageResizer
             $this->notify($callbackNotification, $message, \TYPO3\CMS\Core\Messaging\FlashMessage::ERROR);
         } elseif (!$isRotated && filesize($tempFileInfo[3]) >= $originalFileSize - 10240 && $destExtension === $fileExtension) {
             // Conversion leads to same or bigger file (rounded to 10KB to accomodate tiny variations in compression) => skip!
+            @unlink($tempFileInfo[3]);
             $tempFileInfo = null;
         }
         if ($tempFileInfo) {


### PR DESCRIPTION
@xperseguers this is a small change but can have a huge impact, if i an not wrong:

What it does:

This change should delete the temporary created images in typo3temp/assets/images if they have been skipped (If conversion leads to same or bigger file (rounded to 10KB to accomodate tiny variations in compression)). Otherwhise this can lead to a huge impact, cause the temporary copied files will stay in typo3conf/assets/images and consume a huge amount of unnessessary diskspace (if not cleaned up otherwise) ...