### PR TITLE
[Fix] Add an additional/alternative auto-image-rotate option

### DIFF
--- a/Classes/Service/ImageResizer.php
+++ b/Classes/Service/ImageResizer.php
@@ -310,7 +310,41 @@ class ImageResizer
         if ((bool)$ruleset['auto_orient'] === true) {
             $orientation = ImageUtility::getOrientation($fileName);
             $isRotated = ImageUtility::isRotated($orientation);
-            $gifCreator->scalecmd = '-auto-orient ' . $gifCreator->scalecmd;
+
+            if ((bool)$ruleset['auto_orient_custom'] === true) {
+                switch ((int) $orientation) {
+
+                    case 2:
+                        $gifCreator->scalecmd = '-flop';
+                        break;
+
+                    case 3:
+                        $gifCreator->scalecmd = '-rotate 180';
+                        break;
+
+                    case 4:
+                        $gifCreator->scalecmd = '-rotate 180 -flop';
+                        break;
+
+                    case 5:
+                        $gifCreator->scalecmd = '-rotate -90 -flop';
+                        break;
+
+                    case 6:
+                        $gifCreator->scalecmd = '-rotate -90';
+                        break;
+
+                    case 7:
+                        $gifCreator->scalecmd = '-rotate 90 -flop';
+                        break;
+
+                    case 8:
+                        $gifCreator->scalecmd = '-rotate 90';
+                        break;
+                }
+            } else {
+                $gifCreator->scalecmd = '-auto-orient ' . $gifCreator->scalecmd;
+            }
         }
 
         if (

--- a/Configuration/TCA/Module/Options.php
+++ b/Configuration/TCA/Module/Options.php
@@ -85,6 +85,12 @@ return [
                 'type' => 'check',
             ],
         ],
+        'auto_orient_custom' => [
+            'label' => 'Use custom auto_orient (flop rotate 6 and 8 handling, based on image exif)',
+            'config' => [
+                'type' => 'check',
+            ],
+        ],
         'keep_metadata' => [
             'label' => 'LLL:EXT:image_autoresize/Resources/Private/Language/locallang_tca.xlf:tx_imageautoresize.keep_metadata',
             'config' => [
@@ -121,7 +127,7 @@ return [
             'directories,threshold,file_types,
 			--palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:ALT.imgDimensions;dimensions,
 			--div--;LLL:EXT:image_autoresize/Resources/Private/Language/locallang_tca.xlf:tabs.options,
-				auto_orient,keep_metadata,resize_png_with_alpha,conversion_mapping,
+				auto_orient,auto_orient_custom,keep_metadata,resize_png_with_alpha,conversion_mapping,
 			--div--;LLL:EXT:image_autoresize/Resources/Private/Language/locallang_tca.xlf:tabs.rulesets,
 				rulesets
 		'],


### PR DESCRIPTION
This is more like a workaround for now. Background details:

- On our system, for a so far unknown reason, the exif data (does not depend on the test image, the exif data is as usuall but its not correctly respected somehow) is somehow in cases of 6 and 8 (see exif orientation screenshots in article of next url) not correctly processed with the core "auto_orient" checkbox option (images are NOT rotated correctly)
- This commit intoduces a seperate, additional handling, which basically "inverts" the image-orientation in exif data cases 6 and 8.
- Background info: it should work like this: https://jdhao.github.io/2019/07/31/image_rotation_exif_info/ (and thats also how it is handled so far) but ->

Overall:
It seems somehow not always reliable how to act on the EXIF data. In theory i would totally agree and say that the approach described and explained here (https://jdhao.github.io/2019/07/31/image_rotation_exif_info/) and also currently taken in the core of the extension should be correct, **but**, under some (sadly not yet absolutely clear) circumstances, the auto-orient feature does not work - at least on our new server. And i could imagine that the same happens for the user (https://github.com/DTM-TYPO3)´s usecase in this issue https://github.com/xperseguers/t3ext-image_autoresize/issues/60

Also, the problem has been reported and studied already by others like:

- See this study here: https://www.daveperrett.com/articles/2012/07/28/exif-orientation-handling-is-a-ghetto/ and related repository https://github.com/recurser/exif-orientation-examples
- As well as https://keyj.emphy.de/exif-orientation-rant/

....so thats why i introduced in this branch the additional option. Of course, in best case it would not be needed at all but so far at least it provides a workaround for us and maybe its helpfull for others ... :-)
