### PR TITLE
Added return type to BatchResize::execute()

### DIFF
--- a/Classes/Command/BatchResize.php
+++ b/Classes/Command/BatchResize.php
@@ -59,7 +59,7 @@ class BatchResize extends Command
      * @param OutputInterface $output
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->io = new SymfonyStyle($input, $output);
         $this->io->title('Batch resize images');


### PR DESCRIPTION
Added return type to BatchResize::execute() due to

`Fatal error: Declaration of Causal\ImageAutoresize\Command\BatchResize::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in /var/www/html/htdocs/vendor/causal/image_autoresize/Classes/Command/BatchResize.php on line 62`
