### PR TITLE
[BUGFIX] Prevent Warning caused by invalid enum cast

### DIFF
--- a/Classes/Command/BatchResize.php
+++ b/Classes/Command/BatchResize.php
@@ -226,7 +226,7 @@ class BatchResize extends Command
     public function notify(string $message, $severity)
     {
         if (version_compare((new Typo3Version())->getBranch(), '12.0', '>=')) {
-            $severity = (int)$severity;
+            $severity = $severity->value;
         }
 
         switch ($severity) {


### PR DESCRIPTION
In the BatchResize command, a callback method receiving a $severity variable does not correctly check the type and tries to cast it to an int. However, the value is an enum for Typo3 >= 12 which is not castable to an int.

This PR replaces the typecast with an access to the enums value, which is an int.

Resolves: #108