### PR TITLE
fix: prevent sql error on metadata extraction if DateTimeOriginal = '…

### DIFF
--- a/Classes/Utility/FAL.php
+++ b/Classes/Utility/FAL.php
@@ -182,7 +182,8 @@ class FAL
                                 }
                                 break;
                             case 'DateTimeOriginal':
-                                $value = strtotime($value);
+                                $timestamp = strtotime($value);
+                                $value = ($timestamp !== false && $timestamp > 0) ? $timestamp : null;
                                 break;
                         }
                     }


### PR DESCRIPTION
…0000:00:00 00:00:00'

`-62169984000` is not a valid value for `content_creation_date`