### PR TITLE
Use empty string as default value

### DIFF
--- a/Classes/Command/BatchResize.php
+++ b/Classes/Command/BatchResize.php
@@ -51,7 +51,8 @@ class BatchResize extends Command
         $this->addArgument(
             'excludeDirectories',
             InputArgument::OPTIONAL,
-            'Comma-separated list of directories to exclude from processing'
+            'Comma-separated list of directories to exclude from processing',
+            ''
         );
     }
 


### PR DESCRIPTION
This fixes the following exception when executing
the command 'vendor/bin/typo3 imageautoresize:batchresize':

Uncaught TYPO3 Exception TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(): Argument #2 ($string) must be of type string, null given, called in /var/www/vendor/causal/image_autoresize/Classes/Command/BatchResize.php on line 171 thrown in file /var/www/vendor/typo3/cms-core/Classes/Utility/GeneralUtility.php in line 822